### PR TITLE
IOS-1002 Applies `+1` prefix fix onto Banno's fork of `PhoneNumberKit`

### DIFF
--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -53,6 +53,7 @@ public final class PartialFormatter {
     var currentMetadata: MetadataTerritory?
     var prefixBeforeNationalNumber = String()
     var shouldAddSpaceAfterNationalPrefix = false
+    var showNationalNumberPrefix = true
     var withPrefix = true
 
     // MARK: Status
@@ -116,12 +117,14 @@ public final class PartialFormatter {
         }
         
         var finalNumber = String()
-        if self.prefixBeforeNationalNumber.count > 0 {
-            finalNumber.append(self.prefixBeforeNationalNumber)
-        }
-        if self.shouldAddSpaceAfterNationalPrefix, self.prefixBeforeNationalNumber.count > 0, self.prefixBeforeNationalNumber.last != PhoneNumberConstants.separatorBeforeNationalNumber.first {
-            finalNumber.append(PhoneNumberConstants.separatorBeforeNationalNumber)
-        }
+        if showNationalNumberPrefix {
+             if prefixBeforeNationalNumber.count > 0 {
+                 finalNumber.append(prefixBeforeNationalNumber)
+             }
+             if shouldAddSpaceAfterNationalPrefix && prefixBeforeNationalNumber.count > 0 && prefixBeforeNationalNumber.last != PhoneNumberConstants.separatorBeforeNationalNumber.first  {
+                 finalNumber.append(PhoneNumberConstants.separatorBeforeNationalNumber)
+             }
+         }
         if nationalNumber.count > 0 {
             finalNumber.append(nationalNumber)
         }

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -16,11 +16,11 @@ public final class PartialFormatter {
     weak var parser: PhoneNumberParser?
     weak var regexManager: RegexManager?
 
-    public convenience init(phoneNumberKit: PhoneNumberKit = PhoneNumberKit(), defaultRegion: String = PhoneNumberKit.defaultRegionCode(), withPrefix: Bool = true, withNationalNumberPrefix: Bool = true, maxDigits: Int? = nil) {
-        self.init(phoneNumberKit: phoneNumberKit, regexManager: phoneNumberKit.regexManager, metadataManager: phoneNumberKit.metadataManager, parser: phoneNumberKit.parseManager.parser, defaultRegion: defaultRegion, withPrefix: withPrefix, withNationalNumberPrefix: withNationalNumberPrefix, maxDigits: maxDigits)
+    public convenience init(phoneNumberKit: PhoneNumberKit = PhoneNumberKit(), defaultRegion: String = PhoneNumberKit.defaultRegionCode(), withPrefix: Bool = true, maxDigits: Int? = nil) {
+        self.init(phoneNumberKit: phoneNumberKit, regexManager: phoneNumberKit.regexManager, metadataManager: phoneNumberKit.metadataManager, parser: phoneNumberKit.parseManager.parser, defaultRegion: defaultRegion, withPrefix: withPrefix, maxDigits: maxDigits)
     }
 
-    init(phoneNumberKit: PhoneNumberKit, regexManager: RegexManager, metadataManager: MetadataManager, parser: PhoneNumberParser, defaultRegion: String, withPrefix: Bool = true, withNationalNumberPrefix: Bool = true, maxDigits: Int? = nil) {
+    init(phoneNumberKit: PhoneNumberKit, regexManager: RegexManager, metadataManager: MetadataManager, parser: PhoneNumberParser, defaultRegion: String, withPrefix: Bool = true, maxDigits: Int? = nil) {
         self.phoneNumberKit = phoneNumberKit
         self.regexManager = regexManager
         self.metadataManager = metadataManager
@@ -28,7 +28,6 @@ public final class PartialFormatter {
         self.defaultRegion = defaultRegion
         self.updateMetadataForDefaultRegion()
         self.withPrefix = withPrefix
-        self.showNationalNumberPrefix = withNationalNumberPrefix
         self.maxDigits = maxDigits
     }
 
@@ -54,7 +53,6 @@ public final class PartialFormatter {
     var currentMetadata: MetadataTerritory?
     var prefixBeforeNationalNumber = String()
     var shouldAddSpaceAfterNationalPrefix = false
-    var showNationalNumberPrefix = true
     var withPrefix = true
 
     // MARK: Status
@@ -118,14 +116,11 @@ public final class PartialFormatter {
         }
 
         var finalNumber = String()
-
-        if showNationalNumberPrefix {
-             if prefixBeforeNationalNumber.count > 0 {
-                 finalNumber.append(prefixBeforeNationalNumber)
-             }
-             if shouldAddSpaceAfterNationalPrefix && prefixBeforeNationalNumber.count > 0 && prefixBeforeNationalNumber.last != PhoneNumberConstants.separatorBeforeNationalNumber.first  {
-                 finalNumber.append(PhoneNumberConstants.separatorBeforeNationalNumber)
-             }
+         if self.withPrefix, self.prefixBeforeNationalNumber.count > 0 {
+              finalNumber.append(self.prefixBeforeNationalNumber)
+          }
+        if self.withPrefix, self.shouldAddSpaceAfterNationalPrefix, self.prefixBeforeNationalNumber.count > 0, self.prefixBeforeNationalNumber.last != PhoneNumberConstants.separatorBeforeNationalNumber.first {
+             finalNumber.append(PhoneNumberConstants.separatorBeforeNationalNumber)
          }
         if nationalNumber.count > 0 {
             finalNumber.append(nationalNumber)

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -95,7 +95,7 @@ public final class PartialFormatter {
     public func formatPartial(_ rawNumber: String) -> String {
         // Always reset variables with each new raw number
         self.resetVariables()
-        
+
         guard self.isValidRawNumber(rawNumber) else {
             return rawNumber
         }

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -95,12 +95,12 @@ public final class PartialFormatter {
     public func formatPartial(_ rawNumber: String) -> String {
         // Always reset variables with each new raw number
         self.resetVariables()
-
+        
         guard self.isValidRawNumber(rawNumber) else {
             return rawNumber
         }
         let split = splitNumberAndPausesOrWaits(rawNumber)
-
+        
         var nationalNumber = self.nationalNumber(from: split.number)
         if let formats = availableFormats(nationalNumber) {
             if let formattedNumber = applyFormat(nationalNumber, formats: formats) {
@@ -114,14 +114,14 @@ public final class PartialFormatter {
                 }
             }
         }
-
+        
         var finalNumber = String()
-         if self.withPrefix, self.prefixBeforeNationalNumber.count > 0 {
-              finalNumber.append(self.prefixBeforeNationalNumber)
-          }
+        if self.withPrefix, self.prefixBeforeNationalNumber.count > 0 {
+            finalNumber.append(self.prefixBeforeNationalNumber)
+        }
         if self.withPrefix, self.shouldAddSpaceAfterNationalPrefix, self.prefixBeforeNationalNumber.count > 0, self.prefixBeforeNationalNumber.last != PhoneNumberConstants.separatorBeforeNationalNumber.first {
-             finalNumber.append(PhoneNumberConstants.separatorBeforeNationalNumber)
-         }
+            finalNumber.append(PhoneNumberConstants.separatorBeforeNationalNumber)
+        }
         if nationalNumber.count > 0 {
             finalNumber.append(nationalNumber)
         }

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -16,11 +16,11 @@ public final class PartialFormatter {
     weak var parser: PhoneNumberParser?
     weak var regexManager: RegexManager?
 
-    public convenience init(phoneNumberKit: PhoneNumberKit = PhoneNumberKit(), defaultRegion: String = PhoneNumberKit.defaultRegionCode(), withPrefix: Bool = true, maxDigits: Int? = nil) {
-        self.init(phoneNumberKit: phoneNumberKit, regexManager: phoneNumberKit.regexManager, metadataManager: phoneNumberKit.metadataManager, parser: phoneNumberKit.parseManager.parser, defaultRegion: defaultRegion, withPrefix: withPrefix, maxDigits: maxDigits)
+    public convenience init(phoneNumberKit: PhoneNumberKit = PhoneNumberKit(), defaultRegion: String = PhoneNumberKit.defaultRegionCode(), withPrefix: Bool = true, withNationalNumberPrefix: Bool = true, maxDigits: Int? = nil) {
+        self.init(phoneNumberKit: phoneNumberKit, regexManager: phoneNumberKit.regexManager, metadataManager: phoneNumberKit.metadataManager, parser: phoneNumberKit.parseManager.parser, defaultRegion: defaultRegion, withPrefix: withPrefix, withNationalNumberPrefix: withNationalNumberPrefix, maxDigits: maxDigits)
     }
 
-    init(phoneNumberKit: PhoneNumberKit, regexManager: RegexManager, metadataManager: MetadataManager, parser: PhoneNumberParser, defaultRegion: String, withPrefix: Bool = true, maxDigits: Int? = nil) {
+    init(phoneNumberKit: PhoneNumberKit, regexManager: RegexManager, metadataManager: MetadataManager, parser: PhoneNumberParser, defaultRegion: String, withPrefix: Bool = true, withNationalNumberPrefix: Bool = true, maxDigits: Int? = nil) {
         self.phoneNumberKit = phoneNumberKit
         self.regexManager = regexManager
         self.metadataManager = metadataManager
@@ -28,6 +28,7 @@ public final class PartialFormatter {
         self.defaultRegion = defaultRegion
         self.updateMetadataForDefaultRegion()
         self.withPrefix = withPrefix
+        self.showNationalNumberPrefix = withNationalNumberPrefix
         self.maxDigits = maxDigits
     }
 

--- a/PhoneNumberKit/PartialFormatter.swift
+++ b/PhoneNumberKit/PartialFormatter.swift
@@ -101,7 +101,7 @@ public final class PartialFormatter {
             return rawNumber
         }
         let split = splitNumberAndPausesOrWaits(rawNumber)
-        
+
         var nationalNumber = self.nationalNumber(from: split.number)
         if let formats = availableFormats(nationalNumber) {
             if let formattedNumber = applyFormat(nationalNumber, formats: formats) {
@@ -115,8 +115,9 @@ public final class PartialFormatter {
                 }
             }
         }
-        
+
         var finalNumber = String()
+
         if showNationalNumberPrefix {
              if prefixBeforeNationalNumber.count > 0 {
                  finalNumber.append(prefixBeforeNationalNumber)

--- a/PhoneNumberKit/PhoneNumberKit.swift
+++ b/PhoneNumberKit/PhoneNumberKit.swift
@@ -217,7 +217,7 @@ public final class PhoneNumberKit: NSObject {
     ///
     /// - returns: A computed value for the user's current region - based on the iPhone's carrier and if not available, the device region.
     public class func defaultRegionCode() -> String {
-#if os(iOS) && !targetEnvironment(macCatalyst)
+#if os(iOS) && !targetEnvironment(simulator) && !targetEnvironment(macCatalyst) 
         let networkInfo = CTTelephonyNetworkInfo()
         let carrier = networkInfo.subscriberCellularProvider
         if let isoCountryCode = carrier?.isoCountryCode {


### PR DESCRIPTION
###  References

* Fixes IOS-1002  https://banno-jha.atlassian.net/browse/IOS-1002

###  What is the goal?

* Zelle SDK would like to use `PhoneNumberKit`, but needs a fix from an unmerged PR on the upstream repo.

* Applies this `+1` prefix fix onto Banno's fork of `PhoneNumberKit.PartialFormatter`, taken from their unmerged PR https://github.com/marmelroy/PhoneNumberKit/pull/329

(also see https://github.com/marmelroy/PhoneNumberKit/pull/244/files)

That PR tests good, but the PR has been unmerged for about a year, even as other PRs merge as recently as yesterday. We've upvoted it to hopefully get it back on their radar; in the meantime, we apply their patch to our fork.

### How is it being implemented?

* Applies `PhoneNumberKit`'s prefix fix to `PartialFormatter`, directly from their unmerged PR https://github.com/marmelroy/PhoneNumberKit/pull/329

(also see https://github.com/marmelroy/PhoneNumberKit/pull/244/files)

###  Screenshots or Gifs

None.

###  How to Test

* Checkout Zelle SDK branch https://github.com/Banno/BannoZelleSDK-iOS/pull/582

* Edit the Zelle project's the `Cartfile` line 

```github "Banno/PhoneNumberKit" ~> 3.1.0```

to point to this branch:

```github "Banno/PhoneNumberKit" "bmonk/IOS-1002-applies-prefix-fix-from-unmerged-PhoneNumberKit-PR"```

* On the Zelle branch, run `carthage update --platform iOS`

* Uncomment the two Zelle tests at the bottom of `ZellePhoneNumberFormatterTests.swift` (line 20)

* Uncomment the Zelle test near the top of `TokenFormattedValueTests` (line 24)

* Select Zelle Target `BannoZelleSDK-Debug` and hit Cmd-U.

* Confirm all tests pass


###  Known Issues
None.